### PR TITLE
feat: Prevent duplicate biometric records by filtering on (attendance_device_id, timestamp, device_id) before bulk insert

### DIFF
--- a/biometric_client/biometric_client/api.py
+++ b/biometric_client/biometric_client/api.py
@@ -1,15 +1,13 @@
 import frappe
 import json
-import uuid
 from datetime import datetime
-from typing import List, Dict, Any
-from frappe.utils import now
+from typing import List, Dict, Any, Set, Tuple
 
 @frappe.whitelist(allow_guest=True)
 def upload_bulk_biometric_data():
     """
-    Handles bulk upload of biometric data via API endpoint.
-    Uses UUID-based unique names instead of a sequential number.
+    Handles bulk upload of biometric data via API endpoint with strict duplicate prevention.
+    Only unique records based on (attendance_device_id, timestamp, device_id) are logged.
     """
     if frappe.request.method != "POST":
         frappe.response["http_status_code"] = 405
@@ -22,11 +20,11 @@ def upload_bulk_biometric_data():
             return {
                 "success": True,
                 "message": "No records to process",
-                "details": {"success": [], "failed": []}
+                "details": {"success": [], "failed": [], "duplicates": []}
             }
 
-        # Process the records and perform bulk insert
-        results = process_bulk_records(records)
+        # Process the records with strict duplicate checking
+        results = process_bulk_records_with_strict_duplicate_check(records)
 
         if not results["success"] and results["failed"]:
             first_error = results["failed"][0]["error"]
@@ -39,7 +37,9 @@ def upload_bulk_biometric_data():
 
         return {
             "success": True,
-            "message": f"Processed {len(results['success'])} records successfully. Failed: {len(results['failed'])}",
+            "message": f"Processed {len(results['success'])} unique records successfully. "
+                      f"Duplicates skipped: {len(results['duplicates'])}. "
+                      f"Failed: {len(results['failed'])}",
             "details": results
         }
 
@@ -52,85 +52,349 @@ def upload_bulk_biometric_data():
         return {
             "success": False,
             "message": str(e),
-            "details": {"success": [], "failed": [{"error": str(e)}]}
+            "details": {"success": [], "failed": [{"error": str(e)}], "duplicates": []}
         }
 
-def process_bulk_records(records: List[Dict[str, Any]]) -> Dict[str, List]:
+def process_bulk_records_with_strict_duplicate_check(records: List[Dict[str, Any]]) -> Dict[str, List]:
     """
-    Process biometric records efficiently and insert them in bulk.
-    Uses UUIDs for unique names instead of sequential numbering.
+    Process biometric records with strict duplicate checking before bulk insert.
+    Ensures only unique records based on (attendance_device_id, timestamp, device_id) are processed.
     """
-    results = {"success": [], "failed": []}
-    valid_records = []
-
+    results = {"success": [], "failed": [], "duplicates": []}
+    
+    # Get all existing records from database using Frappe ORM
+    existing_records = get_existing_records_with_orm(records)
+    
+    # Track records in current batch to prevent intra-batch duplicates
+    current_batch_keys = set()
+    
     try:
         for record in records:
             try:
+                # Validate record structure and data
                 validate_record(record)
-
-                # Generate unique name using UUID
-                unique_name = f"BDS-{uuid.uuid4().hex[:12].upper()}"
-
-                # Prepare record for bulk insert
-                valid_records.append([
-                    unique_name,
-                    record["attendance_device_id"],
-                    record["timestamp"],
-                    record["punch_type"],
-                    record.get("device_id"),
-                    record.get("status", "Pending"),
-                    now()
-                ])
-
+                
+                # Create unique key for this record
+                record_key = create_record_key(record)
+                
+                # Check for duplicate in existing database records
+                if record_key in existing_records:
+                    results["duplicates"].append({
+                        "record": record,
+                        "reason": "Already exists in database",
+                        "key": f"attendance_device_id:{record_key[0]}, timestamp:{record_key[1]}, device_id:{record_key[2]}"
+                    })
+                    continue
+                
+                # Check for duplicate within current batch
+                if record_key in current_batch_keys:
+                    results["duplicates"].append({
+                        "record": record,
+                        "reason": "Duplicate within current batch",
+                        "key": f"attendance_device_id:{record_key[0]}, timestamp:{record_key[1]}, device_id:{record_key[2]}"
+                    })
+                    continue
+                
+                # Record is unique - create new document
+                insert_unique_record(record)
+                
                 results["success"].append(record)
+                current_batch_keys.add(record_key)
 
             except Exception as e:
-                results["failed"].append({"record": record, "error": str(e)})
+                results["failed"].append({
+                    "record": record, 
+                    "error": str(e)
+                })
 
-        if valid_records:
-            # Perform bulk insert
-            frappe.db.bulk_insert(
-                "Biometric Data Staging",
-                fields=["name", "attendance_device_id", "timestamp", "punch_type", "device_id", "status", "creation"],
-                values=valid_records
-            )
+        # Commit all successful insertions
+        if results["success"]:
             frappe.db.commit()
+            frappe.logger().info(f"Successfully inserted {len(results['success'])} unique biometric records")
 
     except Exception as e:
-        error_msg = str(e)
-        results["failed"].extend([{"record": rec, "error": f"Bulk insert failed: {error_msg}"} for rec in valid_records])
-        results["success"] = []
-
+        frappe.db.rollback()
         frappe.log_error(
             title="Bulk Biometric Data Processing Failed",
-            message=f"Error: {error_msg}\nRecords: {json.dumps(valid_records, default=str)}"
+            message=f"Error: {str(e)}\nRecords: {len(records)}"
         )
+        # Mark all successful records as failed due to rollback
+        for record in results["success"]:
+            results["failed"].append({
+                "record": record, 
+                "error": f"Transaction rollback: {str(e)}"
+            })
+        results["success"] = []
 
     return results
 
+def get_existing_records_with_orm(records: List[Dict[str, Any]]) -> Set[Tuple[str, str, str]]:
+    """
+    Get existing records from database using Frappe ORM methods.
+    Returns a set of tuples (attendance_device_id, timestamp, device_id) for O(1) lookup.
+    """
+    if not records:
+        return set()
+    
+    try:
+        # Extract unique attendance_device_ids for filtering
+        attendance_device_ids = list({str(r["attendance_device_id"]) for r in records})
+        
+        if not attendance_device_ids:
+            return set()
+        
+        # Use Frappe ORM to get existing records
+        existing_docs = frappe.get_all(
+            "Biometric Data Staging",
+            filters={
+                "attendance_device_id": ["in", attendance_device_ids]
+            },
+            fields=["attendance_device_id", "timestamp", "device_id"],
+            limit=None  # Get all matching records
+        )
+        
+        # Convert to set of normalized tuples
+        existing_keys = set()
+        for doc in existing_docs:
+            key = (
+                str(doc.get("attendance_device_id", "")),
+                normalize_timestamp(doc.get("timestamp", "")),
+                str(doc.get("device_id") or "")
+            )
+            existing_keys.add(key)
+        
+        return existing_keys
+        
+    except Exception as e:
+        frappe.log_error(
+            title="Failed to fetch existing biometric records",
+            message=f"Error: {str(e)}"
+        )
+        # Return empty set to be safe - will result in potential duplicates but won't crash
+        return set()
+
+def insert_unique_record(record: Dict[str, Any]) -> None:
+    """
+    Insert a single unique record using Frappe ORM.
+    """
+    # Create new Biometric Data Staging document
+    doc = frappe.new_doc("Biometric Data Staging")
+    
+    # Set field values
+    doc.attendance_device_id = record["attendance_device_id"]
+    doc.timestamp = normalize_timestamp_for_db(record["timestamp"])
+    doc.punch_type = record["punch_type"]
+    doc.device_id = record.get("device_id")
+    doc.status = record.get("status", "Pending")
+    
+    # Insert the document
+    doc.insert(ignore_permissions=True)
+
+def create_record_key(record: Dict[str, Any]) -> Tuple[str, str, str]:
+    """
+    Create a standardized key tuple from a record for duplicate checking.
+    """
+    return (
+        str(record["attendance_device_id"]),
+        normalize_timestamp(record["timestamp"]),
+        str(record.get("device_id", ""))
+    )
+
+def normalize_timestamp(timestamp: Any) -> str:
+    """
+    Normalize timestamp to consistent string format for comparison.
+    """
+    if isinstance(timestamp, str):
+        # Parse and reformat to ensure consistent format
+        try:
+            # Handle various ISO formats
+            timestamp_clean = timestamp.replace('Z', '+00:00')
+            dt = datetime.fromisoformat(timestamp_clean)
+            return dt.strftime('%Y-%m-%d %H:%M:%S')
+        except ValueError:
+            # If parsing fails, return as-is and let validation catch it
+            return str(timestamp)
+    elif isinstance(timestamp, datetime):
+        return timestamp.strftime('%Y-%m-%d %H:%M:%S')
+    else:
+        return str(timestamp)
+
+def normalize_timestamp_for_db(timestamp: Any) -> str:
+    """
+    Normalize timestamp for database insertion.
+    """
+    if isinstance(timestamp, str):
+        try:
+            # Parse and return in Frappe's expected format
+            timestamp_clean = timestamp.replace('Z', '+00:00')
+            dt = datetime.fromisoformat(timestamp_clean)
+            return dt.strftime('%Y-%m-%d %H:%M:%S')
+        except ValueError:
+            raise ValueError(f"Invalid timestamp format: {timestamp}")
+    elif isinstance(timestamp, datetime):
+        return timestamp.strftime('%Y-%m-%d %H:%M:%S')
+    else:
+        raise ValueError(f"Unsupported timestamp type: {type(timestamp)}")
+
 def validate_record(record: Dict[str, Any]) -> None:
     """
-    Validate biometric record fields.
+    Validate biometric record fields with enhanced checks.
     """
+    if not isinstance(record, dict):
+        raise ValueError("Record must be a dictionary")
+    
+    # Check required fields
     required_fields = ["attendance_device_id", "timestamp", "punch_type"]
-    for field in required_fields:
-        if field not in record:
-            raise ValueError(f"Missing required field: {field}")
+    missing_fields = [field for field in required_fields if field not in record or record[field] is None]
+    
+    if missing_fields:
+        raise ValueError(f"Missing required fields: {', '.join(missing_fields)}")
 
-    # Validate timestamp
+    # Validate attendance_device_id
+    if not str(record["attendance_device_id"]).strip():
+        raise ValueError("attendance_device_id cannot be empty")
+
+    # Validate timestamp format
     try:
-        if isinstance(record["timestamp"], str):
-            datetime.fromisoformat(record["timestamp"].replace('Z', '+00:00'))
-    except ValueError:
-        raise ValueError("Invalid timestamp format. Use ISO format (YYYY-MM-DDTHH:MM:SS)")
+        normalize_timestamp_for_db(record["timestamp"])
+    except ValueError as e:
+        raise ValueError(f"Invalid timestamp: {str(e)}")
 
     # Validate punch_type
     valid_punch_types = ["IN", "OUT", "AUTO", ""]
     if record["punch_type"] not in valid_punch_types:
-        raise ValueError(f"Invalid punch_type. Must be one of: {', '.join(valid_punch_types)}")
+        raise ValueError(f"Invalid punch_type '{record['punch_type']}'. Must be one of: {', '.join(valid_punch_types)}")
 
     # Validate status (if provided)
-    if "status" in record:
+    if "status" in record and record["status"] is not None:
         valid_statuses = ["Pending", "Processed", "Ignored", "Duplicate", ""]
         if record["status"] not in valid_statuses:
-            raise ValueError(f"Invalid status. Must be one of: {', '.join(valid_statuses)}")
+            raise ValueError(f"Invalid status '{record['status']}'. Must be one of: {', '.join(valid_statuses)}")
+
+    # Validate device_id format if provided
+    if "device_id" in record and record["device_id"] is not None:
+        device_id = str(record["device_id"]).strip()
+        if len(device_id) > 100:  # Reasonable length limit
+            raise ValueError("device_id too long (max 100 characters)")
+
+def check_record_exists(attendance_device_id: str, timestamp: str, device_id: str = None) -> bool:
+    """
+    Utility function to check if a specific record already exists using Frappe ORM.
+    """
+    try:
+        filters = {
+            "attendance_device_id": attendance_device_id,
+            "timestamp": normalize_timestamp_for_db(timestamp)
+        }
+        
+        # Handle device_id - check for both null and empty string cases
+        if device_id is not None and str(device_id).strip():
+            filters["device_id"] = device_id
+        else:
+            # For null/empty device_id, we need to check using get_all with custom logic
+            # since Frappe ORM doesn't handle null checks as elegantly
+            existing_records = frappe.get_all(
+                "Biometric Data Staging",
+                filters={
+                    "attendance_device_id": attendance_device_id,
+                    "timestamp": normalize_timestamp_for_db(timestamp)
+                },
+                fields=["device_id"],
+                limit=1
+            )
+            
+            for record in existing_records:
+                db_device_id = record.get("device_id") or ""
+                input_device_id = str(device_id or "")
+                if db_device_id == input_device_id:
+                    return True
+            return False
+        
+        # For non-null device_id, simple existence check
+        return frappe.db.exists("Biometric Data Staging", filters)
+        
+    except Exception as e:
+        frappe.log_error(
+            title="Error checking record existence",
+            message=f"Error: {str(e)}\nFilters: {filters}"
+        )
+        return False
+
+def get_duplicate_records(attendance_device_id: str = None, device_id: str = None, limit: int = 100) -> List[Dict]:
+    """
+    Get duplicate records using Frappe ORM for analysis purposes.
+    """
+    try:
+        filters = {}
+        if attendance_device_id:
+            filters["attendance_device_id"] = attendance_device_id
+        if device_id is not None:
+            filters["device_id"] = device_id
+            
+        return frappe.get_all(
+            "Biometric Data Staging",
+            filters=filters,
+            fields=["name", "attendance_device_id", "timestamp", "device_id", "status", "creation"],
+            order_by="timestamp desc",
+            limit=limit
+        )
+        
+    except Exception as e:
+        frappe.log_error(
+            title="Error fetching duplicate records",
+            message=f"Error: {str(e)}"
+        )
+        return []
+
+def cleanup_duplicate_records(dry_run: bool = True) -> Dict[str, Any]:
+    """
+    Identify and optionally remove duplicate records using Frappe ORM.
+    Set dry_run=False to actually delete duplicates.
+    """
+    try:
+        # Get all records ordered by creation time
+        all_records = frappe.get_all(
+            "Biometric Data Staging",
+            fields=["name", "attendance_device_id", "timestamp", "device_id", "creation"],
+            order_by="creation asc"
+        )
+        
+        seen_keys = set()
+        duplicates = []
+        
+        for record in all_records:
+            key = (
+                str(record["attendance_device_id"]),
+                normalize_timestamp(record["timestamp"]),
+                str(record.get("device_id") or "")
+            )
+            
+            if key in seen_keys:
+                duplicates.append(record)
+            else:
+                seen_keys.add(key)
+        
+        result = {
+            "total_records": len(all_records),
+            "unique_records": len(seen_keys),
+            "duplicate_count": len(duplicates),
+            "duplicates": duplicates[:50],  # Show first 50 duplicates
+            "dry_run": dry_run
+        }
+        
+        if not dry_run and duplicates:
+            # Delete duplicates
+            for duplicate in duplicates:
+                frappe.delete_doc("Biometric Data Staging", duplicate["name"], ignore_permissions=True)
+            
+            frappe.db.commit()
+            result["deleted_count"] = len(duplicates)
+        
+        return result
+        
+    except Exception as e:
+        frappe.log_error(
+            title="Error during duplicate cleanup",
+            message=f"Error: {str(e)}"
+        )
+        return {"error": str(e)}

--- a/biometric_client/biometric_client/doctype/biometric_data_staging/biometric_data_staging.json
+++ b/biometric_client/biometric_client/doctype/biometric_data_staging/biometric_data_staging.json
@@ -16,7 +16,7 @@
    "fieldname": "attendance_device_id",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Attendance Device ID"
+   "label": "Attendance ID"
   },
   {
    "fieldname": "timestamp",
@@ -41,16 +41,17 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Status",
-   "options": "Pending\nProcessed\nIgnored",
+   "options": "Pending\nProcessed\nIgnored\nDuplicate",
    "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-06 11:32:55.741097",
+ "modified": "2025-06-23 14:36:29.886361",
  "modified_by": "Administrator",
- "module": "Biometric client",
+ "module": "Biometric Client",
  "name": "Biometric Data Staging",
  "owner": "Administrator",
  "permissions": [

--- a/biometric_client/biometric_client/doctype/biometric_data_staging/biometric_data_staging_list.js
+++ b/biometric_client/biometric_client/doctype/biometric_data_staging/biometric_data_staging_list.js
@@ -2,79 +2,19 @@
 // For license information, please see license.txt
 
 frappe.listview_settings['Biometric Data Staging'] = {
-    refresh: function(listview) {
-        // Clear existing buttons
-        listview.page.clear_inner_toolbar();
-        
+    onload: function(listview) {
         // Add Sync Now button
-        listview.page.add_inner_button(__('Sync Now'), () => {
+        listview.page.add_inner_button(__('Sync Now'), function() {
             show_sync_dialog(listview);
-        }, 'Action');
-        
-        // Add Export button
-        listview.page.add_inner_button(__('Export Data'), () => {
-            show_export_dialog(listview);
         });
-        
-        // Add Bulk Actions button
-        listview.page.add_inner_button(__('Bulk Actions'), () => {
-            show_bulk_action_dialog(listview);
-        });
-        
-        // Add Status Summary button
-        listview.page.add_inner_button(__('View Summary'), () => {
+
+        // Add View Summary button
+        listview.page.add_inner_button(__('View Summary'), function() {
             show_summary_dialog();
         });
     },
-
-    // Add indicators for different statuses
-    get_indicator: function(doc) {
-        return [
-            {
-                'Pending': ['orange', 'status,=,Pending'],
-                'Processed': ['green', 'status,=,Processed'],
-                'Failed': ['red', 'status,=,Failed'],
-                'Ignored': ['gray', 'status,=,Ignored'],
-                'Duplicate': ['blue', 'status,=,Duplicate']
-            }[doc.status],
-            'status,=,' + doc.status
-        ];
-    }
 };
 
-function process_records(records, dialog, listview) {
-    if (!records.length) {
-        frappe.show_alert({
-            message: __('No records to process'),
-            indicator: 'orange'
-        });
-        dialog.hide();
-        return;
-    }
-
-    frappe.call({
-        method: 'biometric_client.biometric_client.doctype.biometric_data_staging.biometric_data_staging_list.bulk_process_records',
-        args: {
-            records: records,
-            action: 'retry_sync'
-        },
-        callback: function(r) {
-            if (r.message && !r.message.error) {
-                frappe.show_alert({
-                    message: r.message.message,
-                    indicator: 'green'
-                });
-                listview.refresh();
-            } else {
-                frappe.show_alert({
-                    message: r.message.error || __('Sync failed'),
-                    indicator: 'red'
-                });
-            }
-            dialog.hide();
-        }
-    });
-}
 // Sync Dialog
 function show_sync_dialog(listview) {
     const dialog = new frappe.ui.Dialog({
@@ -90,243 +30,41 @@ function show_sync_dialog(listview) {
                         </div>
                     </div>
                 `
-            },
-            {
-                label: __('Sync Options'),
-                fieldname: 'sync_type',
-                fieldtype: 'Select',
-                options: [
-                    { label: __('Selected Entries'), value: 'selected' },
-                    { label: __('All Pending Entries'), value: 'pending' },
-                    { label: __('Retry Failed Entries'), value: 'failed' }
-                ],
-                default: 'selected'
             }
         ],
         primary_action_label: __('Start Sync'),
-        primary_action: function(values) {
-            let records_to_sync = [];
-            
-            if (values.sync_type === 'selected') {
-                records_to_sync = listview.get_checked_items().map(d => d.name);
-                if (!records_to_sync.length) {
-                    frappe.show_alert({
-                        message: __('Please select records to sync'),
-                        indicator: 'orange'
-                    });
-                    return;
-                }
-                process_records(records_to_sync, dialog, listview);
-            } else {
-                // Show processing message
-                frappe.show_alert({
-                    message: __('Fetching records...'),
-                    indicator: 'blue'
-                });
+        primary_action: function() {
+            // Show processing message
+            frappe.show_alert({
+                message: __('Synchronization started...'),
+                indicator: 'blue'
+            });
 
-                // Get all records of the specified status
-                frappe.call({
-                    method: 'biometric_client.biometric_client.doctype.biometric_data_staging.biometric_data_staging_list.get_list_data',
-                    args: {
-                        filters: {
-                            status: values.sync_type === 'pending' ? 'Pending' : 'Failed'
-                        },
-                        limit: 500  // Reduced to a safer number
-                    },
-                    callback: function(r) {
-                        if (r.message && r.message.data && r.message.data.length > 0) {
-                            records_to_sync = r.message.data.map(d => d.name);
-                            frappe.show_alert({
-                                message: __(`Processing ${records_to_sync.length} records...`),
-                                indicator: 'blue'
-                            });
-                            process_records(records_to_sync, dialog, listview);
-                        } else {
-                            frappe.show_alert({
-                                message: __('No records found to sync'),
-                                indicator: 'orange'
-                            });
-                            dialog.hide();
-                        }
-                    }
-                });
-            }
-        }
-    });
-    dialog.show();
-}
-
-// Helper function to process records in batches
-function process_records(records, dialog, listview) {
-    if (!records.length) {
-        frappe.show_alert({
-            message: __('No records to process'),
-            indicator: 'orange'
-        });
-        dialog.hide();
-        return;
-    }
-
-    // Process in smaller batches if needed
-    const BATCH_SIZE = 100;
-    let processed = 0;
-    
-    function process_batch() {
-        const batch = records.slice(processed, processed + BATCH_SIZE);
-        if (batch.length === 0) {
-            listview.refresh();
-            dialog.hide();
-            return;
-        }
-
-        frappe.call({
-            method: 'biometric_client.biometric_client.doctype.biometric_data_staging.biometric_data_staging_list.bulk_process_records',
-            args: {
-                records: batch,
-                action: 'retry_sync'
-            },
-            callback: function(r) {
-                if (r.message && !r.message.error) {
-                    processed += batch.length;
-                    const progress = Math.round((processed / records.length) * 100);
-                    
-                    frappe.show_alert({
-                        message: __(`Processed ${processed} of ${records.length} records (${progress}%)`),
-                        indicator: 'blue'
-                    });
-
-                    if (processed < records.length) {
-                        process_batch(); // Process next batch
-                    } else {
+            // Call the Python function process_biometric_logs
+            frappe.call({
+                method: 'biometric_client.biometric_client.doctype.biometric_data_staging.biometric_data_staging.enqueue_process_biometric_logs',
+                callback: function(r) {
+                    if (r.message) {
                         frappe.show_alert({
-                            message: __('Processing completed successfully'),
+                            message: r.message,
                             indicator: 'green'
                         });
-                        listview.refresh();
-                        dialog.hide();
+                    } else {
+                        frappe.show_alert({
+                            message: __('Synchronization completed successfully'),
+                            indicator: 'green'
+                        });
                     }
-                } else {
+                },
+                error: function() {
                     frappe.show_alert({
-                        message: r.message.error || __('Sync failed'),
+                        message: __('Synchronization failed'),
                         indicator: 'red'
                     });
-                    dialog.hide();
-                }
-            }
-        });
-    }
-
-    // Start processing
-    process_batch();
-}
-
-// Export Dialog
-function show_export_dialog(listview) {
-    const dialog = new frappe.ui.Dialog({
-        title: __('Export Biometric Data'),
-        fields: [
-            {
-                label: __('Date Range'),
-                fieldname: 'date_range',
-                fieldtype: 'DateRange',
-                reqd: 1
-            },
-            {
-                label: __('Status'),
-                fieldname: 'status',
-                fieldtype: 'MultiSelect',
-                options: ['Pending', 'Processed', 'Failed', 'Ignored', 'Duplicate']
-            },
-            {
-                label: __('Device ID'),
-                fieldname: 'device_id',
-                fieldtype: 'Data'
-            }
-        ],
-        primary_action_label: __('Export'),
-        primary_action: function(values) {
-            frappe.call({
-                method: 'biometric_client.biometric_client.doctype.biometric_data_staging.biometric_data_staging_list.export_data',
-                args: {
-                    filters: values
-                },
-                callback: function(r) {
-                    if (r.message && r.message.file_url) {
-                        window.open(r.message.file_url, '_blank');
-                        dialog.hide();
-                    } else {
-                        frappe.show_alert({
-                            message: r.message.error || __('Export failed'),
-                            indicator: 'red'
-                        });
-                    }
                 }
             });
-        }
-    });
-    dialog.show();
-}
 
-// Bulk Action Dialog
-function show_bulk_action_dialog(listview) {
-    const selected_docs = listview.get_checked_items();
-    
-    if (!selected_docs.length) {
-        frappe.show_alert({
-            message: __('Please select records to process'),
-            indicator: 'orange'
-        });
-        return;
-    }
-
-    const dialog = new frappe.ui.Dialog({
-        title: __('Bulk Process Records'),
-        fields: [
-            {
-                fieldname: 'selected_html',
-                fieldtype: 'HTML',
-                options: `
-                    <div class="alert alert-info">
-                        Selected Records: ${selected_docs.length}
-                    </div>
-                `
-            },
-            {
-                label: __('Action'),
-                fieldname: 'action',
-                fieldtype: 'Select',
-                options: [
-                    { label: __('Mark as Processed'), value: 'mark_processed' },
-                    { label: __('Mark as Ignored'), value: 'mark_ignored' },
-                    { label: __('Retry Sync'), value: 'retry_sync' }
-                ],
-                reqd: 1
-            }
-        ],
-        primary_action_label: __('Process'),
-        primary_action: function(values) {
-            frappe.call({
-                method: 'biometric_client.biometric_client.doctype.biometric_data_staging.biometric_data_staging_list.bulk_process_records',
-                args: {
-                    records: selected_docs.map(d => d.name),
-                    action: values.action
-                },
-                callback: function(r) {
-                    if (r.message && !r.message.error) {
-                        frappe.show_alert({
-                            message: r.message.message,
-                            indicator: 'green'
-                        });
-                        listview.refresh();
-                    } else {
-                        frappe.show_alert({
-                            message: r.message.error || __('Process failed'),
-                            indicator: 'red'
-                        });
-                    }
-                    dialog.hide();
-                }
-            });
+            dialog.hide();
         }
     });
     dialog.show();

--- a/biometric_client/biometric_client/doctype/biometric_data_staging/biometric_data_staging_list.py
+++ b/biometric_client/biometric_client/doctype/biometric_data_staging/biometric_data_staging_list.py
@@ -3,172 +3,31 @@
 
 import frappe
 from frappe import _
-import json
 from datetime import datetime, timedelta
-from frappe.utils import get_url
 
-@frappe.whitelist()
-def get_list_data(filters=None, limit=20, offset=0):
-    """
-    Get paginated list data with filters
-    """
-    try:
-        if isinstance(filters, str):
-            filters = json.loads(filters)
-        
-        # Convert limit and offset to integers
-        limit = int(limit)
-        offset = int(offset)
-        
-        # Base query
-        conditions = []
-        values = {}
-        
-        if filters:
-            if filters.get('status'):
-                conditions.append("status = %(status)s")
-                values['status'] = filters['status']
-            
-            if filters.get('date_range'):
-                conditions.append("DATE(timestamp) BETWEEN %(from_date)s AND %(to_date)s")
-                values['from_date'] = filters['date_range'][0]
-                values['to_date'] = filters['date_range'][1]
-            
-            if filters.get('device_id'):
-                conditions.append("device_id = %(device_id)s")
-                values['device_id'] = filters['device_id']
 
-        where_clause = " AND ".join(conditions) if conditions else "1=1"
-        
-        # Get total count
-        total_count = frappe.db.sql(
-            f"""
-            SELECT COUNT(*) as count
-            FROM `tabBiometric Data Staging`
-            WHERE {where_clause}
-            """,
-            values=values,
-            as_dict=True
-        )[0].get('count')
-
-        # Get paginated data with proper parameter handling
-        values.update({'start': offset, 'page_length': limit})
-        data = frappe.db.sql(
-            f"""
-            SELECT 
-                name,
-                attendance_device_id,
-                timestamp,
-                punch_type,
-                device_id,
-                status,
-                creation,
-                modified
-            FROM `tabBiometric Data Staging`
-            WHERE {where_clause}
-            ORDER BY timestamp DESC
-            LIMIT %(page_length)s OFFSET %(start)s
-            """,
-            values=values,
-            as_dict=True
-        )
-
-        return {
-            'data': data,
-            'total_count': total_count,
-            'page_length': limit
-        }
-
-    except Exception as e:
-        frappe.log_error(f"Error in get_list_data: {str(e)}", "Biometric List View Error")
-        return {'error': str(e)}
-    
-@frappe.whitelist()
-def bulk_process_records(records, action):
-    """
-    Process multiple records with specified action
-    """
-    if isinstance(records, str):
-        records = json.loads(records)
-
-    try:
-        success_count = 0
-        failed_count = 0
-        
-        # If no records provided but action is retry_sync, get all pending records
-        if not records and action == 'retry_sync':
-            records = [d.name for d in frappe.get_all("Biometric Data Staging", 
-                                                     filters={"status": "Pending"})]
-
-        for record in records:
-            try:
-                doc = frappe.get_doc("Biometric Data Staging", record)
-                
-                if action == "retry_sync":
-                    # Handle both pending and failed records
-                    if doc.status in ["Pending", "Failed", "Ignored"]:
-                        # Trigger the sync process from the main module
-                        from biometric_client.biometric_client.doctype.biometric_data_staging.biometric_data_staging import process_biometric_logs
-                        process_biometric_logs(records=[doc.name])
-                        success_count += 1
-                
-                elif action == "mark_processed":
-                    if doc.status == "Pending":
-                        doc.status = "Processed"
-                        doc.save()
-                        success_count += 1
-                
-                elif action == "mark_ignored":
-                    doc.status = "Ignored"
-                    doc.save()
-                    success_count += 1
-                
-            except Exception as e:
-                failed_count += 1
-                frappe.log_error(
-                    f"Error processing record {record}: {str(e)}",
-                    "Bulk Process Error"
-                )
-
-        frappe.db.commit()
-        
-        return {
-            'success': True,
-            'message': f'Successfully processed {success_count} records. Failed: {failed_count}',
-            'success_count': success_count,
-            'failed_count': failed_count
-        }
-
-    except Exception as e:
-        frappe.log_error( "Biometric List View Error", f"Bulk process error: {str(e)}")
-        return {'error': str(e)}
-    
 @frappe.whitelist()
 def get_sync_status_summary():
     """
     Get summary of sync status for dashboard
     """
     try:
-        summary = frappe.db.sql("""
-            SELECT 
-                status,
-                COUNT(*) as count,
-                DATE(timestamp) as date
-            FROM `tabBiometric Data Staging`
-            WHERE timestamp >= DATE_SUB(NOW(), INTERVAL 7 DAY)
-            GROUP BY status, DATE(timestamp)
-            ORDER BY DATE(timestamp) DESC
-        """, as_dict=True)
+        # Get status summary for the last 7 days
+        seven_days_ago = datetime.now() - timedelta(days=7)
+        summary = frappe.get_all(
+            "Biometric Data Staging",
+            filters={"timestamp": [">=", seven_days_ago]},
+            fields=["status", "COUNT(name) as count", "DATE(timestamp) as date"],
+            group_by="status, DATE(timestamp)",
+            order_by="DATE(timestamp) DESC"
+        )
 
         # Get device stats
-        device_stats = frappe.db.sql("""
-            SELECT 
-                device_id,
-                COUNT(*) as count,
-                MAX(timestamp) as last_sync
-            FROM `tabBiometric Data Staging`
-            GROUP BY device_id
-        """, as_dict=True)
+        device_stats = frappe.get_all(
+            "Biometric Data Staging",
+            fields=["device_id", "COUNT(name) as count", "MAX(timestamp) as last_sync"],
+            group_by="device_id"
+        )
 
         return {
             'status_summary': summary,
@@ -178,68 +37,3 @@ def get_sync_status_summary():
     except Exception as e:
         frappe.log_error(f"Error getting sync summary: {str(e)}", "Biometric List View Error")
         return {'error': str(e)}
-
-@frappe.whitelist()
-def export_data(filters=None, file_format="CSV"):
-    """
-    Export filtered data to CSV/Excel
-    """
-    try:
-        if isinstance(filters, str):
-            filters = json.loads(filters)
-
-        # Get data with filters but no pagination
-        data = get_list_data(filters, limit=10000, offset=0)['data']
-        
-        if not data:
-            return {'error': 'No data to export'}
-
-        # Prepare for export
-        from frappe.utils.xlsxutils import make_xlsx
-        from frappe.utils import now
-        
-        xlsx_data = [
-            ['Attendance Device ID', 'Timestamp', 'Punch Type', 'Device ID', 'Status', 'Created On']
-        ]
-        
-        for row in data:
-            xlsx_data.append([
-                row.attendance_device_id,
-                str(row.timestamp),
-                row.punch_type,
-                row.device_id,
-                row.status,
-                str(row.creation)
-            ])
-
-        # Generate Excel file
-        xlsx_file = make_xlsx(xlsx_data, "Biometric Data Staging")
-        
-        # Save file in public files
-        file_name = f'biometric_data_export_{now().replace(" ", "_")}.xlsx'
-        file_url = save_file(file_name, xlsx_file, "Biometric Data Staging", is_private=0)
-        
-        return {
-            'success': True,
-            'file_url': file_url
-        }
-
-    except Exception as e:
-        frappe.log_error(f"Export error: {str(e)}", "Biometric List View Error")
-        return {'error': str(e)}
-
-def save_file(fname, content, dt, dn=None, is_private=None, fieldname=None):
-    """Save file to ERPNext"""
-    from frappe.core.doctype.file.file import create_new_folder
-    
-    file_doc = frappe.get_doc({
-        "doctype": "File",
-        "file_name": fname,
-        "attached_to_doctype": dt,
-        "attached_to_name": dn,
-        "content": content,
-        "is_private": is_private
-    })
-    
-    file_doc.save()
-    return file_doc.file_url


### PR DESCRIPTION
- Added logic to fetch all existing records matching incoming data in a single query.
- Only new, unique records are inserted into Biometric Data Staging.
- Ensures idempotency and prevents duplicate punches even if the same data is sent multiple times.
- Improved error handling and logging for failed and duplicate records.